### PR TITLE
Add a hint for locating noisetor.net nodes on torstatus.blutmagie.de

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ into Tor exit nodes.
 <li><a href="https://www.noisebridge.net/mailman/listinfo/tor">Noisebridge Tor mailing list</a></li>
 <li><a href="https://github.com/noisetor/">GitHub project <tt>noisetor</tt></a> which contains source for this website as well as machine config scripts</li>
 <li><a href="http://twitter.com/noisetor"><tt>noisetor</tt> Twitter stream</a></li>
-<li><a href="http://torstatus.blutmagie.de/">torstatus.blutmagie.de</a> gives information about the Tor network.</li>
+<li><a href="http://torstatus.blutmagie.de/">torstatus.blutmagie.de</a> gives information about the Tor network. Search for "noisetor.net" to see our nodes.</li>
 </ul>
 </body>
 </html>


### PR DESCRIPTION
It took me a while to figure out which nodes belong to NoiseTor because the domain is tor.noisebridge.net and I didn't find "noisebridge" on the list of nodes. This hint may help. There's no way to link directly to those nodes in the list, afaict
